### PR TITLE
indentation.rkt : stop spin on unbreakable lines

### DIFF
--- a/gui-lib/scribble/private/indentation.rkt
+++ b/gui-lib/scribble/private/indentation.rkt
@@ -355,7 +355,7 @@
         at-sign-posi
         (for/first ([posi (in-range width (- len 1))] 
                     #:when (equal? 'text (list-ref classify-lst posi)))
-          posi))))
+          (+ start posi)))))
 
 ;;adjust-spaces for text
 ;;(adjust-spaces : a-racket:text para amount posi) → boolean?
@@ -640,6 +640,12 @@
                   (paragraph-indentation t 39 14)
                   (send t get-text))
                 "#lang scribble/base\n\ntestcase @a{b\n\n\n\n\n c}\n\n")
+               
+  (check-equal? (let ([t (new racket:text%)])
+                  (send t insert "#lang scribble/base\n\n@subsubsubsubsection[#:tag \"mrxxxyyyyyyyesqIII\"]{x}\n")
+                  (paragraph-indentation t 39 14)
+                  (send t get-text))
+                "#lang scribble/base\n\n@subsubsubsubsection[#:tag \"mrxxxyyyyyyyesqIII\"]{\n x}\n")
   
   ;;test case for adjust paragraph width
   (check-equal? (let ([t (new racket:text%)])


### PR DESCRIPTION
A bug in insert-break-func caused a spin on lines which can only be broken to the right of width. See the subsubsubsubsection example.

posi iterates from (+ start width) in the first half of the function, but only from width at the bottom. changed to add start to the return value.
